### PR TITLE
Fixed excessive time.Now() calls

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -72,11 +72,12 @@ func (l *Logger) PopProcessor() {
 func (l *Logger) AddRecord(level Severity, message string, context interface{}) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	r := newRecord(level, l.Name, message, context)
 
 	if !l.S(level) {
 		return
 	}
+
+	r := newRecord(level, l.Name, message, context)
 
 	for k := range l.processors {
 		l.processors[k].Process(r)


### PR DESCRIPTION
Creating the record before checking the log level induces the call to `time.Now()` and a syscall. When having many log calls that are ignored, this creates a lot of unneeded syscalls.
